### PR TITLE
fix(yaml): prevent same-indent mapping entries from nesting incorrectly

### DIFF
--- a/yaml/parser.mbt
+++ b/yaml/parser.mbt
@@ -421,8 +421,8 @@ fn Parser::parse_mapping_with_first_key(
           let exits_level = if base_indent != -1 {
             dn < base_indent
           } else {
-            // If base_indent is not set, Dedent(0) means we're at top level
-            dn == 0
+            // If base_indent is not set, any Dedent means we've exited our scope
+            true
           }
           if exits_level {
             // Special case: Dedent(0) means we're back at top level
@@ -565,6 +565,12 @@ fn Parser::parse_block_sequence(
         }
         if should_consume {
           let _ = self.advance()
+        }
+        // Check if there's another dash at this level (sibling sequence item)
+        // This handles the case where a nested mapping exits and we're back at sequence level
+        self.skip_trivia()
+        if self.peek_kind() == Some(Dash) {
+          continue // Continue parsing next sequence item
         }
         break
       }

--- a/yaml/parser_test.mbt
+++ b/yaml/parser_test.mbt
@@ -222,6 +222,44 @@ test "yaml_parse_sequence_item_with_multiple_keys" {
 }
 
 ///|
+/// Test Issue #5: same-indent mapping entries should be siblings, not nested
+/// https://github.com/anthropics/yyjj.mbt/issues/5
+test "yaml_parse_sibling_mappings_same_indent" {
+  let yaml = (
+    #|jobs:
+    #|  build:
+    #|    runs-on: ubuntu-latest
+    #|  lint:
+    #|    runs-on: ubuntu-latest
+  )
+  let result = @yaml.parse(yaml)
+  guard result is Ok(@yaml.YMapping(pairs, _)) else {
+    println("Parse failed or not a mapping")
+    return
+  }
+  // Should have 1 top-level key: jobs
+  inspect(pairs.length(), content="1")
+  // jobs should be a mapping with 2 sibling keys: build, lint
+  guard pairs[0].value is @yaml.YMapping(jobs_value, _) else {
+    println("Expected nested mapping for 'jobs'")
+    return
+  }
+  // Critical assertion: build and lint are siblings (2 entries), NOT lint nested in build
+  inspect(jobs_value.length(), content="2")
+  // Verify the keys
+  guard jobs_value[0].key is @yaml.YString(key1, _, _) else {
+    println("Expected string key for first entry")
+    return
+  }
+  inspect(key1, content="build")
+  guard jobs_value[1].key is @yaml.YString(key2, _, _) else {
+    println("Expected string key for second entry")
+    return
+  }
+  inspect(key2, content="lint")
+}
+
+///|
 /// Test that 'on' keyword is preserved as a key (not converted to 'true')
 test "yaml_parse_on_keyword_as_key" {
   let yaml = "on:\n  push: main"


### PR DESCRIPTION
## Summary

Fixes #5

* CSTパーサーで同じインデントレベルのマッピングエントリが誤ってネストされる問題を修正
* `parse_mapping_with_first_key`: `base_indent`未設定時は任意のDedentで終了し、親パーサーに処理を委譲
* `parse_block_sequence`: Dedent後に次の`Dash`があればシーケンス解析を継続

## Test plan

- [x] 新規テスト `yaml_parse_sibling_mappings_same_indent` でIssue #5のケースを検証
- [x] 既存の55テストすべて通過
- [x] GitHub Actionsワークフロー形式のYAMLが正しくパースされることを確認