### PR TITLE
Fix: YAML parser incorrectly places properties after nested mappings at parent level

### DIFF
--- a/yaml/parser.mbt
+++ b/yaml/parser.mbt
@@ -768,8 +768,8 @@ fn Parser::parse_indented_mapping(
     // Exit if we've dedented past our level
     match self.peek_kind() {
       Some(Dedent(n)) => {
-        // Exit if dedented to or below our base level
-        if n <= base_indent {
+        // Exit if dedented below our base level
+        if n < base_indent {
           // Don't consume the dedent - let the caller handle it
           break
         }


### PR DESCRIPTION
## Root Cause
In parse_indented_mapping, the condition n <= base_indent caused premature exit when a dedent returned exactly to the base_indent level.

## Fix
Changed condition from n <= base_indent to n < base_indent so that:
- Parser continues when dedented to the base level (n == base_indent)
- Parser only exits when dedented below the base level (n < base_indent)